### PR TITLE
chore(`Pipfile`): make package versions explicit

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,5 +6,7 @@ name = "pypi"
 [packages]
 
 [dev-packages]
-coverage = "*"
-flake8 = "*"
+coverage = "~=7.6"
+flake8 = "~=7.1"
+setuptools = "~=71.0"
+wheel = "~=0.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f636e4b9b3a9da229cba92f3f940270a6604328915c3ae14c4c21f7ca71c3d52"
+            "sha256": "965bdf6b9cfb1abf11b2f2cc76caf369ec31ddd57273b0ef4fba31c6dba3642c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -106,6 +106,24 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==3.2.0"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:48297e5d393a62b7cb2a10b8f76c63a73af933bd809c9e0d0d6352a1a0135dd8",
+                "sha256:ed2feca703be3bdbd94e6bb17365d91c6935c6b2a8d0bb09b66a2c435ba0b1a5"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==71.0.4"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85",
+                "sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.43.0"
         }
     }
 }


### PR DESCRIPTION
- instead of accepting any version (*) accept only those versions which have a common major number (~=)