### PR TITLE
Add support for missing CLI options

### DIFF
--- a/src/daylio_to_md/__main__.py
+++ b/src/daylio_to_md/__main__.py
@@ -30,6 +30,7 @@ def main():
     Librarian(
         cli_options.filepath,
         cli_options.destination,
+        force_overwrite=cli_options.force,
         entries_from_builder=file_template
     ).output_all()
 

--- a/src/daylio_to_md/config.py
+++ b/src/daylio_to_md/config.py
@@ -86,7 +86,6 @@ def parse_console(args: List[Any]) -> argparse.Namespace:
         type=str,
         help="Path to folder to output finished files into."
     )
-    # TODO: Force-argument does nothing yet.
     main_settings.add_argument(
         "--force",
         choices=["accept", "refuse"],

--- a/src/daylio_to_md/entry/mood.py
+++ b/src/daylio_to_md/entry/mood.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 from typing import List
 
-from daylio_to_md import errors
+from daylio_to_md import errors, utils
+from daylio_to_md.utils import JsonLoader
 
 DEFAULT_DAYLIO_MOOD_GROUPS = "rad good neutral bad awful"
 
@@ -186,3 +187,21 @@ class Moodverse:
         :return: ``dict[str, str]`` where keys are moods and their values are mood groups they belong to
         """
         return self.__known_moods
+
+
+def create_from(filepath: str = None) -> 'Moodverse':
+    """
+    Overwrite the standard mood-set with a custom one. Mood-sets are used in colour-coding each dated entry.
+
+    :param filepath: path to the .JSON file with a non-standard mood set.
+     Should have five keys: ``rad``, ``good``, ``neutral``, ``bad`` and ``awful``.
+     Each of those keys should hold an array of any number of strings indicating various moods.
+     **Example**: ``[{"good": ["good"]},...]``
+    :returns: reference to the :class:`Moodverse` object
+    """
+    try:
+        with JsonLoader().load(filepath) as file:
+            return Moodverse(file)
+    except utils.CouldNotLoadFileError:
+        # oh, no! anyway... just load up a default moodverse then
+        return Moodverse()

--- a/src/daylio_to_md/errors.py
+++ b/src/daylio_to_md/errors.py
@@ -32,16 +32,32 @@ class ColorHandler(logging.StreamHandler):
         self.stream.write(f"{csi}{color}m{formatted_msg}{csi}m\n")
 
 
+class DuplicateFilter(logging.Filter):
+    # Class-level attribute to store logged messages
+    logged_messages = set()
+
+    def filter(self, record):
+        # Create a unique identifier for the log message
+        current_log = (record.module, record.levelno, record.msg)
+
+        if current_log in DuplicateFilter.logged_messages:
+            return False  # Filter out the message if it's a duplicate
+
+        DuplicateFilter.logged_messages.add(current_log)
+        return True  # Allow the log through if it's not a duplicate
+
+
 # Create a console handler for the root logger
 # noinspection SpellCheckingInspection
 console_log_handler = ColorHandler(sys.stdout)
+console_log_handler.addFilter(DuplicateFilter())
 # interesting discussion on why setLevel on both handler AND logger: https://stackoverflow.com/a/17668861/8527654
+
 console_log_handler.setLevel(logging.INFO)
-
 # noinspection SpellCheckingInspection
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-console_log_handler.setFormatter(formatter)
+formatter = logging.Formatter("%(name)s\t%(levelname)s\t%(message)s")
 
+console_log_handler.setFormatter(formatter)
 # Add the handlers to the root logger
 logging.getLogger().addHandler(console_log_handler)
 logging.getLogger().setLevel(logging.INFO)

--- a/src/daylio_to_md/group.py
+++ b/src/daylio_to_md/group.py
@@ -21,6 +21,7 @@ from daylio_to_md import utils, errors
 from daylio_to_md.config import DEFAULTS
 from daylio_to_md.journal_entry import Entry
 from daylio_to_md.entry.mood import Moodverse
+from daylio_to_md.utils import IncompleteDataRow
 
 # TODO: dependency_injector lib
 # TODO: fixtures
@@ -36,14 +37,6 @@ class EntryMissingError(KeyError):
     def __init__(self, key, date):
         self.__doc__ = self.__doc__.format(key=key, date=date)
         super().__init__()
-
-
-class IncompleteDataRow(Exception):
-    """Passed a row of data from CSV file that does not have all required fields."""
-
-
-class TriedCreatingDuplicateDatedEntryError(Exception):
-    """Tried to create object of :class:`DatedEntry` that would be a duplicate of one that already exists."""
 
 
 class ErrorMsg(errors.ErrorMsgBase):
@@ -134,9 +127,8 @@ class EntriesFrom(utils.Core):
         Create :class:`Entry` object with the specified parameters.
         Field with date is ignored, because :class:`Entry` inherits this field from parent :class:`EntriesFrom`.
         The assumption here is that .create_entry() should never be called for an entry from a different date.
-        :raises TriedCreatingDuplicateDatedEntryError: if it would result in making a duplicate :class:`DatedEntry`
         :raises IncompleteDataRow: if ``line`` does not have ``time mood`` keys at the very least, or either is empty
-        :raises ValueError: re-raises ValueError from :class:`DatedEntry`
+        :raises ValueError: re-raises ValueError from :class:`Entry`
         :param line: a dictionary of strings. Required keys: mood, activities, note_title & note.
         """
         # TODO: test case this
@@ -145,10 +137,10 @@ class EntriesFrom(utils.Core):
             try:
                 line[key]
             except KeyError as err:
-                raise IncompleteDataRow(key) from err
+                raise IncompleteDataRow(key, '') from err
             # is it empty then, maybe?
             if not line[key]:
-                raise IncompleteDataRow(key)
+                raise IncompleteDataRow(key, '')
 
         # TODO: date mismatch - this object has a different date than the full_date in line
 

--- a/src/daylio_to_md/group.py
+++ b/src/daylio_to_md/group.py
@@ -6,6 +6,9 @@ Here's a quick breakdown of what is the specialisation of this file in the journ
 all notes -> _NOTES WRITTEN ON A PARTICULAR DATE_ -> a particular note
 """
 from __future__ import annotations
+
+import os
+import pathlib
 from dataclasses import dataclass, field
 
 import io
@@ -246,11 +249,14 @@ class EntriesFrom(utils.Core):
         return self.__known_entries
 
     @property
-    def date(self):
+    def date(self) -> datetime.date:
         """
         :return: :class:`datetime.date` object that identifies this instance of :class:`EntriesFrom`.
         """
         return self.uid
+
+    def path(self, *dest: typing.Union[os.PathLike, str]) -> pathlib.Path:
+        return pathlib.Path(*dest, str(self.date.year), str(self.date.month), f"{self.date}.md")
 
     def __eq__(self, other) -> bool:
         """Enables direct comparison with a :class:`datetime.date` or a date string. """

--- a/src/daylio_to_md/journal_entry.py
+++ b/src/daylio_to_md/journal_entry.py
@@ -175,11 +175,13 @@ class Entry(utils.Core):
         # e.g. "## great | 11:00 AM | Oh my, what a night!"
         # header_multiplier is an int that multiplies the # to create headers in markdown
         header_elements = [
-            self.__header_multiplier * "#" + ' ' + self.__mood,
+            self.__prefix,
+            self.__mood,
             self.time.strftime("%H:%M"),
-            self.__title
+            self.__title,
+            self.__suffix
         ]
-        header = ' | '.join([el for el in header_elements if el is not None])
+        header = self.__header_multiplier * "#" + ' ' + ' | '.join([el for el in header_elements if el])
         chars_written += stream.write(header)
         # ACTIVITIES
         # e.g. "bicycle skating pool swimming"

--- a/src/daylio_to_md/librarian.py
+++ b/src/daylio_to_md/librarian.py
@@ -272,8 +272,7 @@ class Librarian:
 
     def output_all(self):
         """
-        Loops through known dates and calls :class:`DatedEntriesGroup` to output its contents inside the destination.
-        :raises NoDestinationSelectedError: when the parent object has been instantiated without a destination set.
+        Loops through known dates and calls each :class:`EntriesFrom` to output its contents inside the destination.
         """
         for known_date in self.__known_dates.values():
             # "2022/11/09/2022-11-09.md"

--- a/src/daylio_to_md/utils.py
+++ b/src/daylio_to_md/utils.py
@@ -278,7 +278,7 @@ class CsvLoader(FileLoader):
             expected_field not in fieldnames
         }
         if len(missing_strings) > 0:
-            self.__logger.critical(CSV_FIELDS_MISSING.format(', '.join(missing_strings)))
+            self.logger.critical(CSV_FIELDS_MISSING.format(', '.join(missing_strings)))
             raise InvalidDataInFileError(expected_fields, fieldnames)
 
         self.logger.debug(CSV_ALL_FIELDS_PRESENT.format(', '.join(missing_strings)))

--- a/src/daylio_to_md/utils.py
+++ b/src/daylio_to_md/utils.py
@@ -171,7 +171,7 @@ class FileLoader:
         pass
 
     @contextmanager
-    def load(self, path: str) -> None:
+    def load(self, path: str) -> typing.Any:
         """
         Loads the file into context manager and catches exceptions thrown while doing so.
         It catches errors specific to the implementation first, then tries to catch more general IO errors.
@@ -306,3 +306,7 @@ def guess_time_type(this: typing.Union[datetime.time, str, typing.List[str], typ
         raise InvalidTimeError(this)
 
     return proper_time_obj.replace(second=0, microsecond=0)
+
+
+def ensure_dir(filepath):
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)

--- a/src/daylio_to_md/utils.py
+++ b/src/daylio_to_md/utils.py
@@ -232,7 +232,7 @@ class FileLoader:
         :return: It is not specified what kind of object will be returned when opened. Left up to implementation.
         """
         try:
-            with open(expand_path(path), encoding='UTF-8') as file:
+            with open(expand_path(path), encoding='UTF-8-sig') as file:
                 yield self._load_file(file)
         # TypeError is thrown when a None argument is passed
         except (FileNotFoundError, PermissionError, OSError, UnicodeDecodeError, TypeError) as err:

--- a/tests/files/scenarios/ok/expect/2022-10-26.md
+++ b/tests/files/scenarios/ok/expect/2022-10-26.md
@@ -2,10 +2,6 @@
 tags: daylio
 ---
 
-## captivated | 22:00
-#at-the-office #board-game #colleague-interaction #big-social-gathering
-Sed ut est interdum
-
 ## tired | 20:00 | Mauris rutrum diam
 #allegro #at-the-office #board-game #colleague-interaction #big-social-gathering
 Quisque dictum odio quis augue consectetur, at convallis żodio aliquam.

--- a/tests/files/scenarios/partially-ok/too-many-cells.csv
+++ b/tests/files/scenarios/partially-ok/too-many-cells.csv
@@ -1,0 +1,6 @@
+full_date,date,weekday,time,mood,activities,note_title,note
+2022-10-30,October 30,Sunday,10:04 AM,vaguely ok,2ćities  skylines | dó#lóó fa$$s_ą%,"Dolomet","Lorem ipsum sit dolomet amęt.","yet another cell","too many cells!"
+2022-10-27,October 27,Thursday,1:49 PM,vaguely good,chess,"Cras pretium","Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+2022-10-27,October 27,,12:00 AM,fatigued,allegro | working remotely,"Suspendisse sit amet","Phaśellus pharetra justo ac dui lacinia ullamcorper."
+2022-10-26,October 26,Wednesday,10:00 PM,,at the office | board game | colleague interaction | big social gathering,,"Sed ut est interdum",
+2022-10-26,October 26,Wednesday,8:00 PM,tired,allegro | at the office | board game | colleague interaction | big social gathering,"Mauris rutrum diam","Quisque dictum odio quis augue consectetur, at convallis żodio aliquam."

--- a/tests/test_journal_entry.py
+++ b/tests/test_journal_entry.py
@@ -25,6 +25,7 @@ class TestJournalEntry(TestCase):
         self.assertIsNone(bare_minimum_entry.note)
         self.assertListEqual([], bare_minimum_entry.activities)
 
+    @suppress.out
     def test_bare_minimum_journal_entries_from_builder_class(self):
         # When
         bare_minimum_entry = EntryBuilder().build(

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -168,6 +168,69 @@ class TestEntriesFromOutput(TestCase):
                 # ---
                 self.assertEqual(compare_stream.getvalue(), my_fake_file_stream.getvalue())
 
+    @suppress.out
+    def test_valid_prefix_and_valid_suffix(self):
+        # WHEN
+        # ---
+        # Configure entries to output with prefixes and a suffixes in their headings
+        my_config = EntryBuilder(prefix="I felt", suffix="when doing:")
+        my_entry = my_config.build(time="11:00", mood="great", title="Feeling pumped!", activities="biking")
+
+        with io.StringIO() as my_fake_file_stream:
+            my_entry.output(my_fake_file_stream)
+            # AND
+            # ---
+            # Then create another stream and fill it with the same content, but written directly, not through object
+            with io.StringIO() as compare_stream:
+                compare_stream.write("## I felt | great | 11:00 | Feeling pumped! | when doing:\n")
+                compare_stream.write("#biking")
+
+                # THEN
+                # ---
+                self.assertEqual(compare_stream.getvalue(), my_fake_file_stream.getvalue())
+
+    @suppress.out
+    def test_invalid_prefix_and_valid_suffix(self):
+        # WHEN
+        # ---
+        # Configure entries to output with prefixes and a suffixes in their headings
+        my_config = EntryBuilder(prefix=None, suffix="when doing:")
+        my_entry = my_config.build(time="11:00", mood="great", title="Feeling pumped!", activities="biking")
+
+        with io.StringIO() as my_fake_file_stream:
+            my_entry.output(my_fake_file_stream)
+            # AND
+            # ---
+            # Then create another stream and fill it with the same content, but written directly, not through object
+            with io.StringIO() as compare_stream:
+                compare_stream.write("## great | 11:00 | Feeling pumped! | when doing:\n")
+                compare_stream.write("#biking")
+
+                # THEN
+                # ---
+                self.assertEqual(compare_stream.getvalue(), my_fake_file_stream.getvalue())
+
+    @suppress.out
+    def test_empty_prefix_and_suffix(self):
+        # WHEN
+        # ---
+        # Configure entries to output with prefixes and a suffixes in their headings
+        my_config = EntryBuilder(prefix="", suffix="when doing:")
+        my_entry = my_config.build(time="11:00", mood="great", title="Feeling pumped!", activities="biking")
+
+        with io.StringIO() as my_fake_file_stream:
+            my_entry.output(my_fake_file_stream)
+            # AND
+            # ---
+            # Then create another stream and fill it with the same content, but written directly, not through object
+            with io.StringIO() as compare_stream:
+                compare_stream.write("## great | 11:00 | Feeling pumped! | when doing:\n")
+                compare_stream.write("#biking")
+
+                # THEN
+                # ---
+                self.assertEqual(compare_stream.getvalue(), my_fake_file_stream.getvalue())
+
 
 class TestDatedEntriesGroup(TestCase):
     def setUp(self):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -4,7 +4,7 @@ import shutil
 from unittest import TestCase
 
 import tests.suppress as suppress
-from daylio_to_md.group import EntriesFrom, EntriesFromBuilder
+from daylio_to_md.group import EntriesFrom
 from daylio_to_md.journal_entry import Entry, EntryBuilder
 from daylio_to_md.librarian import Librarian
 
@@ -194,6 +194,7 @@ class TestEntriesFromOutput(TestCase):
         # WHEN
         # ---
         # Configure entries to output with prefixes and a suffixes in their headings
+        # noinspection PyTypeChecker
         my_config = EntryBuilder(prefix=None, suffix="when doing:")
         my_entry = my_config.build(time="11:00", mood="great", title="Feeling pumped!", activities="biking")
 
@@ -321,6 +322,7 @@ class TestDatedEntriesGroup(TestCase):
         # WHEN
         # ---
         # Create a sample date
+        # noinspection PyTypeChecker
         sample_date = EntriesFrom("2011-10-10", front_matter_tags=["", None])
         entry_one = Entry(
             time="10:00 AM",
@@ -361,6 +363,7 @@ class TestDatedEntriesGroup(TestCase):
         # WHEN
         # ---
         # Create a sample date
+        # noinspection PyTypeChecker
         sample_date = EntriesFrom("2011-10-10", front_matter_tags=["", "foo", "bar", None])
         entry_one = Entry(
             time="10:00 AM",


### PR DESCRIPTION
Program now (hopefully) correctly responds to options that have been part of the help, but did not have any implementation:

- prefix
- suffix
- auto-reject all file conflicts
- auto-accept all file overwrites
<!--- START AUTOGENERATED NOTES --->
# Contents ([#25](https://github.com/DeutscheGabanna/Obsidian-Daylio-Parser/pull/25))

### New features
- Auto-accept or auto-refuse writing over existing files in case of conflict

### Enhancements
- Filter out duplicate logs

### Fixes
- Use custom `prefix` and `suffix` in entry headings if set
- typo in `Librarian` class
- Adjust expected files so that they reflect actual proper output

### Refactoring
- Handle .md files in a dedicated class

<!--- END AUTOGENERATED NOTES --->