### PR TITLE
FEAT: Add publishing to TestPyPi workflow

### DIFF
--- a/.github/workflows/publish-test.yaml
+++ b/.github/workflows/publish-test.yaml
@@ -1,0 +1,35 @@
+name: Upload Obsidian Daylio Parser to Test PyPi
+
+on:
+  push:
+    branches:
+      - development
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - name: Check-out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1 # Shallow clone to speed up the workflow
+      - name: Set up Python env
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Build
+        run: |
+          python -m pip install build
+          python -m build
+      - name: Publish on Test PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-test.yaml
+++ b/.github/workflows/publish-test.yaml
@@ -3,7 +3,13 @@ name: Upload Obsidian Daylio Parser to Test PyPi
 on:
   push:
     branches:
-      - development
+      - dev-stage
+    # unless the push modifies actual dev-stage code, don't publish (no point)
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'LICENSE'
+      - '.idea/**'
+      - 'README.md'
 
 permissions:
   contents: read

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,6 +1,13 @@
 name: Pylint
 
-on: [push]
+on:
+  push:
+    # unless the PR modifies actual code, don't run the lints
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'LICENSE'
+      - '.idea/**'
+      - 'README.md'
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,12 @@
 name: Test
-on: [ pull_request ]
+on:
+  pull_request:
+    # unless the PR modifies actual code, don't run the tests
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'LICENSE'
+      - '.idea/**'
+      - 'README.md'
 jobs:
   test:
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,11 @@
-# TODO: make dynamic: version, description, readme, licence
 [project]
 name = "daylio-obsidian-parser"
-version = "0.2"
+dynamic = ["version", "readme"]
 requires-python = ">= 3.8"
 authors = [
 	{name = "Paweł Ilnicki", email = "59067099+DeutscheGabanna@users.noreply.github.com"}
 ]
 description = "Converts Daylio app .csv file into markdown files for use in Obsidian."
-readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE", content-type = "text/markdown"}
 classifiers = [
 	"Topic :: Text Processing :: Markup :: Markdown",
@@ -26,5 +24,14 @@ keywords = [ "csv", "markdown", ".md", ".csv", "daylio", "obsidian", "file conve
 daylio_to_md = "daylio_to_md.__main__:main"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "build", "wheel", "versioningit"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+readme = {file = "README.md", content-type = "text/markdown"}
+
+[tool.versioningit]
+vcs = "git"
+next-version = "null"
+[tool.versioningit.tag2version]
+rmprefix = "v."


### PR DESCRIPTION
Also I split the repo into two environments - `production` and `development`. `development` branch publishes onto TestPyPi and `production` obviously publishes into PyPi.
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#27](https://github.com/DeutscheGabanna/Obsidian-Daylio-Parser/pull/27))

#### ✨ New features
- Add publishing to TestPyPi workflow

#### 🔀 Other
- Avoid running workflows if not necessary

<!--- END AUTOGENERATED NOTES --->