### PR TITLE
FIX | Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Daylio is an amazing journaling and mood-tracking app, but you may want to store
 ## Installation
 If you are an end-user and wish to just convert your .csv file into markdown:
 ```commandline
-pip install obsidian-daylio-parser
+pip install daylio-obsidian-parser
 daylio_to_md --help
 ```
 


### PR DESCRIPTION
The pip package name was messed up
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#30](https://github.com/DeutscheGabanna/Obsidian-Daylio-Parser/pull/30))

#### ❓ Uncategorised!
- FIX | Typo in README.md

<!--- END AUTOGENERATED NOTES --->