### PR TITLE
FIX: Typo in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Daylio is an amazing journaling and mood-tracking app, but you may want to store
 ## Installation
 If you are an end-user and wish to just convert your .csv file into markdown:
 ```commandline
-pip install obsidian-daylio-parser
+pip install daylio-obsidian-parser
 daylio_to_md --help
 ```
 


### PR DESCRIPTION
Messed up the order of words in the package name
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#31](https://github.com/DeutscheGabanna/Obsidian-Daylio-Parser/pull/31))

#### 🐛 Fixes
- Typo in installation command

<!--- END AUTOGENERATED NOTES --->